### PR TITLE
Added TSnackbar.setMaxWidth() method to allow overriding value

### DIFF
--- a/topsnackbar/src/main/java/com/androidadvance/topsnackbar/TSnackbar.java
+++ b/topsnackbar/src/main/java/com/androidadvance/topsnackbar/TSnackbar.java
@@ -221,6 +221,22 @@ public final class TSnackbar {
         return this;
     }
 
+  /**
+   * Overrides the max width of this snackbar's layout. This is typically not necessary; the snackbar
+   * width will be according to Google's Material guidelines. Specifically, the max width will be
+   * {@link com.androidadvance.topsnackbar.R.dimen.design_snackbar_max_width}.
+   *
+   * To allow the snackbar to have a width equal to the parent view, set a value <= 0.
+   *
+   * @param maxWidth  the max width in pixels
+   * @return this TSnackbar
+   */
+  public TSnackbar setMaxWidth(int maxWidth) {
+      mView.mMaxWidth = maxWidth;
+
+      return this;
+  }
+
     private Drawable fitDrawable(Drawable drawable, int sizePx) {
         if (drawable.getIntrinsicWidth() != sizePx || drawable.getIntrinsicHeight() != sizePx) {
 


### PR DESCRIPTION
The max width value is already set through the layout but is not exposed for
clients to change it. In most cases, changing the max width is not necessary,
especially because it currently matches Google's Material guidelines. But
there may be cases where a designer would prefer to treat this as simply an
animated view that shows at the top of the screen instead of a snackbar.
