### PR TITLE
Add ability to define an action that doesn't dismiss snackbar on click

### DIFF
--- a/topsnackbar/src/main/java/com/androidadvance/topsnackbar/TSnackbar.java
+++ b/topsnackbar/src/main/java/com/androidadvance/topsnackbar/TSnackbar.java
@@ -20,7 +20,6 @@ import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.design.widget.CoordinatorLayout;
-import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.SwipeDismissBehavior;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewCompat;
@@ -291,6 +290,11 @@ public final class TSnackbar {
     
     @NonNull
     public TSnackbar setAction(CharSequence text, final View.OnClickListener listener) {
+        return setAction(text, true, listener);
+    }
+
+    @NonNull
+    public TSnackbar setAction(CharSequence text, final boolean shouldDismissOnClick, final View.OnClickListener listener) {
         final TextView tv = mView.getActionView();
 
         if (TextUtils.isEmpty(text) || listener == null) {
@@ -303,8 +307,10 @@ public final class TSnackbar {
                 @Override
                 public void onClick(View view) {
                     listener.onClick(view);
-                    
-                    dispatchDismiss(Callback.DISMISS_EVENT_ACTION);
+
+                    if(shouldDismissOnClick) {
+                        dispatchDismiss(Callback.DISMISS_EVENT_ACTION);
+                    }
                 }
             });
         }


### PR DESCRIPTION
Add the ability to define an action that won't dismiss the snackbar on the action click

I'm using TSnackbar as a network issue alert with length indeterminate, opening settings with action button. I'd like to not dismiss on click as the network issues haven't necessarily been resolved. Quick example:
`snackbar.setAction("Open Wifi Settings", false, v -> NetworkUtil.openWifiSettings(this));`

Note: I'm not breaking existing setAction's, e.g:

`snackbar.setAction("Open Wifi Settings", v -> NetworkUtil.openWifiSettings(this));` will still dismiss on click by default.