### PR TITLE
Using old Snackbar Instance

### DIFF
--- a/topsnackbar/src/main/java/com/androidadvance/topsnackbar/TSnackbar.java
+++ b/topsnackbar/src/main/java/com/androidadvance/topsnackbar/TSnackbar.java
@@ -742,7 +742,7 @@ public final class TSnackbar {
         @Override
         protected void onLayout(boolean changed, int l, int t, int r, int b) {
             super.onLayout(changed, l, t, r, b);
-            if (changed && mOnLayoutChangeListener != null) {
+            if (mOnLayoutChangeListener != null) {
                 mOnLayoutChangeListener.onLayoutChange(this, l, t, r, b);
             }
         }


### PR DESCRIPTION
Fixed an issue when an empty layout is shown when trying to show the snackbar after the first time. Each time a new Instance of snackbar is used to show instead of using the old snack bar instance this fix will allow to use the same instance of the snackbar